### PR TITLE
Increase expanded content max-height for mobile

### DIFF
--- a/public/styles/site/sections/jobs.less
+++ b/public/styles/site/sections/jobs.less
@@ -119,7 +119,7 @@
         }
 
         .description {
-          max-height: 2000px; //Ideally we would set this to 'none', but numeric value is required for transition
+          max-height: 10000px; //Ideally we would set this to 'none', but numeric value is required for transition
           margin-bottom: 0;
         }
       }

--- a/public/styles/site/sections/mission.less
+++ b/public/styles/site/sections/mission.less
@@ -52,7 +52,7 @@
 		
       .collapsible-statement {
         .lead {
-          max-height: 2000px; //Ideally we would set this to 'none', but numeric value is required for transition
+          max-height: 10000px; //Ideally we would set this to 'none', but numeric value is required for transition
           margin-bottom: 0;
         }
       }


### PR DESCRIPTION
Really, we want to not have to define a specific number and just unset the max-height value. However, because the content transitions in, it needs a numeric value to step against. On mobile, the content is much narrower, which makes it much longer - hence the huge value used.
